### PR TITLE
Fix packats status functions according to the datasheet

### DIFF
--- a/sx126x.c
+++ b/sx126x.c
@@ -464,25 +464,25 @@ esp_err_t sx126x_get_rx_buffer_status(sx126x_handle_t* handle, uint8_t* out_payl
     return res;
 }
 
-esp_err_t sx126x_get_packet_status_lora(sx126x_handle_t* handle, uint8_t* out_rx_status, uint8_t* out_rssi_sync,
-                                        uint8_t* out_rssi_avg) {
+esp_err_t sx126x_get_packet_status_lora(sx126x_handle_t* handle, float* out_snr_pkt_db, float* out_rssi_pkt_dbm, 
+                                        float* out_signal_rssi_pkt_db) {
     if (handle == NULL) return ESP_ERR_INVALID_ARG;
-    uint8_t   result[4] = {0};
-    esp_err_t res       = sx126x_command(handle, SX126X_CMD_GET_PACKET_STATUS, NULL, result, sizeof(result));
-    if (res == ESP_OK && out_rx_status) *out_rx_status = result[1];
-    if (res == ESP_OK && out_rssi_sync) *out_rssi_sync = result[2];
-    if (res == ESP_OK && out_rssi_avg) *out_rssi_avg = result[3];
+    uint8_t result[5] = {0};
+    esp_err_t res = sx126x_command(handle, SX126X_CMD_GET_PACKET_STATUS, NULL, result, sizeof(result));
+    if (res == ESP_OK && out_rssi_pkt_dbm) *out_rssi_pkt_dbm = (float)(-result[2] / 2.0f);
+    if (res == ESP_OK && out_snr_pkt_db) *out_snr_pkt_db = (float)(result[3] / 4.0f);
+    if (res == ESP_OK && out_signal_rssi_pkt_db) *out_signal_rssi_pkt_db = (float)(-result[4] / 2.0f);
     return res;
 }
 
-esp_err_t sx126x_get_packet_status_gfsk(sx126x_handle_t* handle, uint8_t* out_rx_status, uint8_t* out_rssi_sync,
-                                        uint8_t* out_rssi_avg) {
+esp_err_t sx126x_get_packet_status_gfsk(sx126x_handle_t* handle, uint8_t* out_rx_status, float* out_rssi_sync_dbm,
+                                        float* out_rssi_avg_dbm) {
     if (handle == NULL) return ESP_ERR_INVALID_ARG;
-    uint8_t   result[4] = {0};
-    esp_err_t res       = sx126x_command(handle, SX126X_CMD_GET_PACKET_STATUS, NULL, result, sizeof(result));
-    if (res == ESP_OK && out_rx_status) *out_rx_status = result[1];
-    if (res == ESP_OK && out_rssi_sync) *out_rssi_sync = result[2];
-    if (res == ESP_OK && out_rssi_avg) *out_rssi_avg = result[3];
+    uint8_t result[5] = {0};
+    esp_err_t res = sx126x_command(handle, SX126X_CMD_GET_PACKET_STATUS, NULL, result, sizeof(result));
+    if (res == ESP_OK && out_rx_status) *out_rx_status = result[2];
+    if (res == ESP_OK && out_rssi_sync_dbm) *out_rssi_sync_dbm = (float)(-result[3] / 2.0f);
+    if (res == ESP_OK && out_rssi_avg_dbm) *out_rssi_avg_dbm = (float)(-result[4] / 2.0f);
     return res;
 }
 

--- a/sx126x.h
+++ b/sx126x.h
@@ -261,10 +261,10 @@ esp_err_t sx126x_set_buffer_base_address(sx126x_handle_t* handle, uint8_t tx_bas
 esp_err_t sx126x_set_lora_symb_num_timeout(sx126x_handle_t* handle, uint8_t symb_num);
 esp_err_t sx126x_get_status(sx126x_handle_t* handle, uint8_t* out_command_status, uint8_t* out_chip_mode);
 esp_err_t sx126x_get_rx_buffer_status(sx126x_handle_t* handle, uint8_t* out_payload_length, uint8_t* out_start_pointer);
-esp_err_t sx126x_get_packet_status_lora(sx126x_handle_t* handle, uint8_t* out_rx_status, uint8_t* out_rssi_sync,
-                                        uint8_t* out_rssi_avg);
-esp_err_t sx126x_get_packet_status_gfsk(sx126x_handle_t* handle, uint8_t* out_rx_status, uint8_t* out_rssi_sync,
-                                        uint8_t* out_rssi_avg);
+esp_err_t sx126x_get_packet_status_lora(sx126x_handle_t* handle, float* out_snr_pkt_db, float* out_rssi_pkt_dbm, 
+                                        float* out_signal_rssi_pkt_db);
+esp_err_t sx126x_get_packet_status_gfsk(sx126x_handle_t* handle, uint8_t* out_rx_status, float* out_rssi_sync_dbm,
+                                        float* out_rssi_avg_dbm);
 esp_err_t sx126x_get_rssi_inst(sx126x_handle_t* handle, float* out_signal_power);
 esp_err_t sx126x_get_stats_lora(sx126x_handle_t* handle, uint16_t* out_nb_pkt_received, uint16_t* out_nb_pkt_crc_error,
                                 uint16_t* out_nb_pkt_header_error);


### PR DESCRIPTION
GetPacketStatus command return 5 bytes according to datasheet, where:
for FSK packet type: 0 byte - reserved, 1 byte - Status, 2 byte - RxStatus, 3 byte - RssiSync, 4 byte - RssiAvg;
for LoRa packet type: 0 byte - reserved, 1 byte - Status, 2 byte - RssiPkt, 3 byte - SnrPkt, 4 byte - SignalRssiPkt.
In the proposed version, correct byte is set for the corresponding value. Also, returned values are scaled, so for convenience, this values are devided by scale factor (could be found in table 13-80 from datashet).